### PR TITLE
Add KafkaMessageProducer unit test

### DIFF
--- a/KafkaProducerDemo/pom.xml
+++ b/KafkaProducerDemo/pom.xml
@@ -27,6 +27,13 @@
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>
+
+        <!-- Testing Dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/KafkaProducerDemo/src/test/java/com/example/kafkaproducerdemo/service/KafkaMessageProducerTest.java
+++ b/KafkaProducerDemo/src/test/java/com/example/kafkaproducerdemo/service/KafkaMessageProducerTest.java
@@ -1,0 +1,27 @@
+package com.example.kafkaproducerdemo.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaMessageProducerTest {
+
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Test
+    void sendMessageShouldCallKafkaTemplateSend() {
+        String topic = "testTopic";
+        KafkaMessageProducer producer = new KafkaMessageProducer(kafkaTemplate, topic);
+        String message = "Hello";
+
+        producer.sendMessage(message);
+
+        verify(kafkaTemplate).send(topic, message);
+    }
+}


### PR DESCRIPTION
## Summary
- add `spring-boot-starter-test` dependency
- create `KafkaMessageProducerTest` using Mockito to verify `send()` invocation

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472d51f28883268a7d33d44ecf7042